### PR TITLE
Devices from UISP

### DIFF
--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -104,9 +104,12 @@ var deviceListCmd = &cobra.Command{
 					nodeNumberStr = fmt.Sprintf("%d", nn)
 				}
 
-				if meshDev, ok := meshDevs[dev.NodeNumber]; ok {
-					log.Printf("found meshapi dev nn:%d from uisp device name %s", dev.NodeNumber, localdso.Identification.Name)
-					dev.MeshAPI = meshDev
+				for _, d := range meshDevs {
+					if d.Name == dev.UISP.Identification.Name && d.NodeID == dev.NodeNumber {
+						log.Printf("found meshapi dev nn:%d from uisp device name %s", dev.NodeNumber, localdso.Identification.Name)
+						dev.MeshAPIDevice = d
+						break
+					}
 				}
 
 				orderedDevs = append(orderedDevs, &dev)

--- a/pkg/app/devices.go
+++ b/pkg/app/devices.go
@@ -7,10 +7,27 @@ import (
 
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/client/devices"
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/client/sites"
+	"github.com/byxorna/nycmesh-tool/generated/go/uisp/models"
 	"github.com/byxorna/nycmesh-tool/pkg/nycmesh"
 )
 
-func (a *App) Devices(ids ...string) (map[int]*nycmesh.Device, error) {
+type FusedDevice struct {
+	NodeNumber int                          `json:"nn"`
+	MeshAPI    *nycmesh.Device              `json:"nycmesh"`
+	UISP       *models.DeviceStatusOverview `json:"uisp"`
+}
+
+func (a *App) UISPDevices() ([]*models.DeviceStatusOverview, error) {
+	log.Printf("UISPDevices()")
+	ok, err := a.UISPAPI.Devices.GetDevices(devices.NewGetDevicesParams(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return ok.Payload, nil
+}
+
+func (a *App) MeshAPIDevices(ids ...string) (map[int]*nycmesh.Device, error) {
 	nodes, err := a.Nodes()
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch devices: %w", err)

--- a/pkg/app/devices.go
+++ b/pkg/app/devices.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FusedDevice struct {
-	NodeNumber int                          `json:"nn"`
-	MeshAPI    *nycmesh.Device              `json:"nycmesh"`
-	UISP       *models.DeviceStatusOverview `json:"uisp"`
+	NodeNumber    int                          `json:"nn"`
+	MeshAPINode   *nycmesh.Node                `json:"meshapi_node"`
+	MeshAPIDevice *nycmesh.Device              `json:"meshapi_device"`
+	UISP          *models.DeviceStatusOverview `json:"uisp_device"`
 }
 
 func (a *App) UISPDevices() ([]*models.DeviceStatusOverview, error) {


### PR DESCRIPTION
This PR adds the beginning of fusing the `mesh-api` device struct with the `uisp` device struct. Right now, I am showing the `nn` if I can extract it via regex from the device's name (in UISP), along with firmware, frequency, channel width, and link score %. If you use `--format=json` (the default), you can extract further fields as you see fit. (`bin/nycmesh-tool devices list --format=json | jq 'length'`)


```
[19:39:14] ~/code/nycmesh-tool gabe/devices-freq* ❱ bin/nycmesh-tool devices list -f table|head
Using config file: /home/gabe/.nycmesh-tool.yaml
2022/01/08 19:39:17 UISPDevices()
NAME                                    NN      MAC                     MODEL           TYPE            SITE                            IP                      FIRMWARE        FREQUENCY CHWIDTH  LINKSCORE% 
nycmesh-lbelr-5305                      5305    74:83:c2:ac:46:ff       LBE-5AC-LR      airMax          Stations-PH-3461                10.70.179.174/24        8.7.4           5490      40       13        
nycmesh-1933-nbe-1934                   1933    04:18:d6:c8:bd:d2       NBE-5AC-19      airMax          Grand Street - 1933             10.97.227.104/26        8.7.1           5810      40       73        
nycmesh-lbe-1163                        1163    b4:fb:e4:32:e5:3f       LBE-5AC-Gen2    airMax          Stations-100AVA-2274            10.97.34.247/26         8.7.1           5745      40       36        
nycmesh-3662-omni                       3662                            UNKNOWN         blackBox        Stations-Saratoga-1340          10.99.147.129                           0         0                  
nycmesh-1933-east-s3                    1933    f0:9f:c2:ec:46:b3       PS-5AC          airMax          Grand Street - 1933             10.97.227.109/26        8.7.1           5710      40       28        
nycmesh-4706-omni                       4706                            UNKNOWN         blackBox        Stations-Saratoga-1340          10.100.152.129                          0         0                  
nycmesh-lbe-6182                        6182    74:83:c2:e8:9b:f3       LBE-5AC-Gen2    airMax          Stations-SN1-227                10.70.74.101/24         8.7.4           5560      40       65        
nycmesh-4128-omni                       4128                            UNKNOWN         blackBox        Stations-Saratoga-1340          10.100.8.1                              0         0                  
nycmesh-nbe-2590                        2590    78:8a:20:14:bb:c7       NBE-5AC-Gen2    airMax          Stations-Rivington-2463         10.70.161.62/24         8.7.1           5710      40       39        
...
```