### PR TITLE
add version checking feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION_PACKAGE := $(PACKAGE)/pkg/version
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_DESCRIBE := $(shell git describe --always HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-GO_LDFLAGS := -X $(VERSION_PACKAGE).GitCommit=$(GIT_COMMIT) -X "$(VERSION_PACKAGE).BuildDate=$(shell date -u)" -X "$(VERSION_PACKAGE).GitDescribe=$(GIT_DESCRIBE)" -X "$(VERSION_PACKAGE).GitBranch=$(GIT_BRANCH)"
+GO_LDFLAGS := -X $(VERSION_PACKAGE).GitCommit=$(GIT_COMMIT) -X "$(VERSION_PACKAGE).BuildDate=$(shell date -u)" -X "$(VERSION_PACKAGE).Release=$(GIT_DESCRIBE)" -X "$(VERSION_PACKAGE).GitBranch=$(GIT_BRANCH)"
 timestamp := $(shell date +%s)
 
 .PHONY: codegen

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/btree v1.0.0 // indirect
+	github.com/google/go-github/v41 v41.0.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -43,6 +45,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	go.mongodb.org/mongo-driver v1.7.5 // indirect
+	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,10 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
+github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -591,6 +595,7 @@ golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa h1:idItI2DDfCokpg0N51B2VtiLdJ4vAuXC9fnCb2gACo4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -44,7 +44,7 @@ func New(cmd *cobra.Command, args []string) (*App, error) {
 }
 
 func VersionString() string {
-	return fmt.Sprintf("%s (commit:%s branch:%s built:%s)", version.GitDescribe, version.GitCommit, version.GitBranch, version.BuildDate)
+	return fmt.Sprintf("%s (commit:%s branch:%s built:%s)", version.Release, version.GitCommit, version.GitBranch, version.BuildDate)
 }
 
 func (a *App) MeshAPINodes(ids ...string) (map[int]nycmesh.Node, error) {

--- a/pkg/selfupdate/version.go
+++ b/pkg/selfupdate/version.go
@@ -59,7 +59,7 @@ func (c *Client) HasNewerRelease(ctx context.Context, releaseAssetName string) (
 			if exeStat.ModTime().After(rel.Published) {
 				// assuming local binary built newer than release, you
 				// are running a newer build than released
-				return nil, fmt.Errorf("new release %s found, but running executable (%s) is modified more recently", rel.TagName, version.Release)
+				return nil, fmt.Errorf("running executable is release %s, which is newer than available release %s", version.Release, rel.TagName)
 			}
 		}
 	}

--- a/pkg/selfupdate/version.go
+++ b/pkg/selfupdate/version.go
@@ -1,0 +1,122 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/byxorna/nycmesh-tool/pkg/version"
+	"github.com/google/go-github/v41/github"
+)
+
+var (
+	ErrNoNewRelease    = fmt.Errorf("no newer release available")
+	ErrConnectionError = fmt.Errorf("network connection error")
+)
+
+type Client struct {
+	github *github.Client
+}
+
+type Release struct {
+	Name          string
+	Body          string
+	TagName       string
+	Published     time.Time
+	DownloadURL   string
+	URL           string
+	Commit        string
+	DownloadCount int
+}
+
+func NewUpdaterGithub() (*Client, error) {
+	return &Client{
+		github: github.NewClient(nil),
+	}, nil
+}
+
+func (c *Client) HasNewerRelease(ctx context.Context, releaseAssetName string) (*Release, error) {
+	org, repo, err := getGithubOrgRepoFromPkgPath()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine github org and repo from package path: %w", err)
+	}
+	rel, err := c.getLatestRelease(ctx, org, repo, releaseAssetName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get latest release: %w", err)
+	}
+
+	if version.Release == rel.TagName {
+		return nil, ErrNoNewRelease
+	}
+
+	if exePath, err := os.Executable(); err == nil {
+		// if the exe we were invoked with is still available, stat it and
+		// see whether mtime is older than when the release was published
+		if exeStat, err := os.Stat(exePath); err == nil {
+			if exeStat.ModTime().After(rel.Published) {
+				// assuming local binary built newer than release, you
+				// are running a newer build than released
+				return nil, fmt.Errorf("new release %s found, but running executable (%s) is modified more recently", rel.TagName, version.Release)
+			}
+		}
+	}
+
+	if version.Release == rel.TagName {
+		return nil, ErrNoNewRelease
+	}
+	return rel, nil
+}
+
+func (c *Client) getLatestRelease(ctx context.Context, ghorg, ghrepo, releaseAssetName string) (*Release, error) {
+	ghrel, _, err := c.github.Repositories.GetLatestRelease(ctx, ghorg, ghrepo)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve latest release: %w", err)
+	}
+	rel := Release{
+		Name:      ghrel.GetName(),
+		TagName:   ghrel.GetTagName(),
+		Body:      ghrel.GetBody(),
+		Published: ghrel.GetPublishedAt().Time,
+		URL:       ghrel.GetURL(),
+		Commit:    ghrel.GetTargetCommitish(),
+	}
+
+	if releaseAssetName != "" {
+		// try to find the download URL matching
+		for _, ra := range ghrel.Assets {
+			if ra.GetName() == releaseAssetName && ra.BrowserDownloadURL != nil {
+				rel.DownloadURL = ra.GetBrowserDownloadURL()
+				rel.DownloadCount = ra.GetDownloadCount()
+				break
+			}
+		}
+	}
+
+	return &rel, nil
+}
+
+// look at our import path to figure out how we are named, and if we are using the
+// github.com import path, pull out the org and repo
+func getGithubOrgRepoFromPkgPath() (string, string, error) {
+	pc, _, _, _ := runtime.Caller(2)
+	partsx := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	pl := len(partsx)
+	packageName := ""
+	funcName := partsx[pl-1]
+
+	if partsx[pl-2][0] == '(' {
+		funcName = partsx[pl-2] + "." + funcName
+		packageName = strings.Join(partsx[0:pl-2], ".")
+	} else {
+		packageName = strings.Join(partsx[0:pl-1], ".")
+	}
+
+	parts := strings.Split(packageName, "/")
+	if len(parts) <= 3 || parts[0] != "github.com" || parts[2] != "nycmesh-tool" {
+		return "", "", fmt.Errorf("unable to determine github org and repo from pkg import - version check will be disabled %+v", parts)
+	}
+	return parts[1], parts[2], nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,8 +1,12 @@
 package version
 
 var (
-	GitCommit   string = "unknown"
-	GitBranch   string = "unknown"
-	GitDescribe string
-	BuildDate   string
+	GitCommit string = "unknown"
+	GitBranch string = "unknown"
+	Release   string
+	BuildDate string
+
+	YY = XX{}
 )
+
+type XX struct{}


### PR DESCRIPTION
The tool now notifies you on startup if there are newer releases available.

Maybe we can clean this up in the future to support real selfupdate by replacing the running executable? This seems like something that's dangerous and vulnerable to exploitation, but still worth noodling on. 