### PR TITLE
mesh-api: refactoring

### DIFF
--- a/cmd/meshapi_devices.go
+++ b/cmd/meshapi_devices.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/byxorna/nycmesh-tool/pkg/app"
-	"github.com/byxorna/nycmesh-tool/pkg/nycmesh"
+	"github.com/byxorna/nycmesh-tool/pkg/meshapi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -77,7 +77,7 @@ var deviceListCmd = &cobra.Command{
 		headers := []string{"NN", "Name", "ID", "SSID", "Mfg", "Model", "Geo", "Status", "Notes"}
 		data := make([][]string, len(meshDevs))
 
-		allDevList := []*nycmesh.Device{}
+		allDevList := []*meshapi.Device{}
 		for _, d := range meshDevs {
 			locald := d
 			allDevList = append(allDevList, locald)
@@ -96,7 +96,7 @@ var deviceListCmd = &cobra.Command{
 		case "table":
 			for _, d := range allDevList {
 				// populate table columns
-				data = append(data, []string{fmt.Sprintf("%d", d.NodeID), d.Name, fmt.Sprintf("%d", d.ID), d.SSID, d.Type.Manufacturer, d.Type.Name, nycmesh.GeoURI(d.Latitude, d.Longitude, d.AltitudeMeters), d.Status, d.Notes})
+				data = append(data, []string{fmt.Sprintf("%d", d.NodeID), d.Name, fmt.Sprintf("%d", d.ID), d.SSID, d.Type.Manufacturer, d.Type.Name, meshapi.GeoURI(d.Latitude, d.Longitude, d.AltitudeMeters), d.Status, d.Notes})
 			}
 			a.Tableify(headers, data)
 		default:

--- a/cmd/meshapi_kml.go
+++ b/cmd/meshapi_kml.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/byxorna/nycmesh-tool/pkg/app"
+	"github.com/spf13/cobra"
+)
+
+var kmlCmd = &cobra.Command{
+	Use:   "kml",
+	Short: "Fetch the mesh-api's KML of the network",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		a, err := app.New(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		kml, err := a.MeshAPIKML()
+		if err != nil {
+			return fmt.Errorf("unable to fetch KML: %w", err)
+		}
+
+		fmt.Printf("%s\n", kml)
+
+		return nil
+	},
+}
+
+func init() {
+	meshapiCmd.AddCommand(kmlCmd)
+}

--- a/cmd/meshapi_nodes.go
+++ b/cmd/meshapi_nodes.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/byxorna/nycmesh-tool/pkg/app"
-	"github.com/byxorna/nycmesh-tool/pkg/nycmesh"
+	"github.com/byxorna/nycmesh-tool/pkg/meshapi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -89,7 +89,7 @@ var nodeListCmd = &cobra.Command{
 		}
 		sort.Ints(nodeNumbers)
 
-		orderedNodes := []*nycmesh.Node{}
+		orderedNodes := []*meshapi.Node{}
 		for _, nn := range nodeNumbers {
 			n := nodes[nn]
 
@@ -97,7 +97,7 @@ var nodeListCmd = &cobra.Command{
 				orderedNodes = append(orderedNodes, &n)
 				data = append(data, []string{
 					fmt.Sprintf("%d", n.ID),
-					nycmesh.GeoURI(n.Latitude, n.Longitude, n.AltitudeMeters),
+					meshapi.GeoURI(n.Latitude, n.Longitude, n.AltitudeMeters),
 					fmt.Sprintf("%s", n.Status),
 					fmt.Sprintf("%d", len(n.Devices)),
 					fmt.Sprintf("%s", n.Building),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -48,6 +48,10 @@ func VersionString() string {
 	return fmt.Sprintf("%s (commit:%s branch:%s built:%s)", version.Release, version.GitCommit, version.GitBranch, version.BuildDate)
 }
 
+func (a *App) MeshAPIKML() ([]byte, error) {
+	return a.MeshAPIClient.KML()
+}
+
 func (a *App) MeshAPINodes(ids ...string) (map[int]meshapi.Node, error) {
 	var idInts []int
 	if len(ids) > 0 {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -58,7 +59,61 @@ func (a *App) MeshAPINodes(ids ...string) (map[int]meshapi.Node, error) {
 			idInts = append(idInts, i)
 		}
 	}
-	return a.MeshAPIClient.Nodes(idInts...)
+
+	///
+
+	var body []byte
+	var err error
+	if !a.diskCache.Has("nodes") {
+		// get nodes from API
+		nodes, err := a.MeshAPIClient.Nodes()
+		// write ndoes into cache if its happy
+		if err != nil {
+			return nil, fmt.Errorf("error getting mesh-api nodes: %w", err)
+		}
+
+		// TODO: this could be improved with a proper read-thru cache, but I don't
+		// want to implement it :P
+		// Regardless, this cache deserialization business could definitely be
+		// DRYed up somewhat...
+
+		if x, err := json.Marshal(&nodes); err != nil {
+			return nil, fmt.Errorf("unable to marshal nodes for caching: %w", err)
+		} else {
+			err = a.diskCache.Write("nodes", x)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	body, err = a.diskCache.Read("nodes")
+	if err != nil {
+		return nil, fmt.Errorf("cache error: %w", err)
+	}
+
+	// TODO: here too, we could DRY this unmarshalling. having to deserialize structs outside
+	// the meshapi package is pretty rough...
+	var nodes []meshapi.Node
+	if err = json.Unmarshal(body, &nodes); err != nil {
+		return nil, fmt.Errorf("unable to decode nodes: %w\n%s", err, body)
+	}
+
+	idFilter := map[int]bool{}
+	for _, id := range idInts {
+		idFilter[id] = true
+	}
+
+	m := map[int]meshapi.Node{}
+	for _, node := range nodes {
+		if _, matchesFilter := idFilter[node.ID]; !matchesFilter && len(idFilter) > 0 {
+			// only return nodes that match provided filter if necessary
+			continue
+		}
+		m[node.ID] = node
+	}
+
+	return m, nil
 }
 
 func getIDFilter(args []string) (map[int]interface{}, error) {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -7,16 +7,16 @@ import (
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/cli"
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/client"
 	"github.com/byxorna/nycmesh-tool/pkg/cache"
-	"github.com/byxorna/nycmesh-tool/pkg/nycmesh"
+	"github.com/byxorna/nycmesh-tool/pkg/meshapi"
 	"github.com/byxorna/nycmesh-tool/pkg/version"
 	"github.com/spf13/cobra"
 )
 
 type App struct {
 	*client.UISPAPI
-	MeshAPIClient *nycmesh.Client
+	MeshAPIClient *meshapi.Client
 
-	// TODO: wire this up as a general caching layer, instead of if being in nycmesh.Client?
+	// TODO: wire this up as a general caching layer, instead of if being in meshapi.Client?
 	diskCache cache.DiskCache
 }
 
@@ -35,7 +35,7 @@ func New(cmd *cobra.Command, args []string) (*App, error) {
 	}
 	a.UISPAPI = c
 
-	nycmeshClient, err := nycmesh.New()
+	nycmeshClient, err := meshapi.New()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create nycmesh client: %w", err)
 	}
@@ -47,7 +47,7 @@ func VersionString() string {
 	return fmt.Sprintf("%s (commit:%s branch:%s built:%s)", version.Release, version.GitCommit, version.GitBranch, version.BuildDate)
 }
 
-func (a *App) MeshAPINodes(ids ...string) (map[int]nycmesh.Node, error) {
+func (a *App) MeshAPINodes(ids ...string) (map[int]meshapi.Node, error) {
 	var idInts []int
 	if len(ids) > 0 {
 		idFilter, err := getIDFilter(ids)

--- a/pkg/app/devices.go
+++ b/pkg/app/devices.go
@@ -8,13 +8,13 @@ import (
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/client/devices"
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/client/sites"
 	"github.com/byxorna/nycmesh-tool/generated/go/uisp/models"
-	"github.com/byxorna/nycmesh-tool/pkg/nycmesh"
+	"github.com/byxorna/nycmesh-tool/pkg/meshapi"
 )
 
 type FusedDevice struct {
 	NodeNumber    int                          `json:"nn"`
-	MeshAPINode   *nycmesh.Node                `json:"meshapi_node"`
-	MeshAPIDevice *nycmesh.Device              `json:"meshapi_device"`
+	MeshAPINode   *meshapi.Node                `json:"meshapi_node"`
+	MeshAPIDevice *meshapi.Device              `json:"meshapi_device"`
 	UISP          *models.DeviceStatusOverview `json:"uisp_device"`
 }
 
@@ -27,7 +27,7 @@ func (a *App) UISPDevices() ([]*models.DeviceStatusOverview, error) {
 	return ok.Payload, nil
 }
 
-func (a *App) MeshAPIDevices(ids ...string) (map[int]*nycmesh.Device, error) {
+func (a *App) MeshAPIDevices(ids ...string) (map[int]*meshapi.Device, error) {
 	nodes, err := a.MeshAPIClient.Nodes()
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch devices: %w", err)
@@ -42,7 +42,7 @@ func (a *App) MeshAPIDevices(ids ...string) (map[int]*nycmesh.Device, error) {
 		idFilter[n] = true
 	}
 
-	devs := map[int]*nycmesh.Device{}
+	devs := map[int]*meshapi.Device{}
 	for _, n := range nodes {
 		for _, d := range n.Devices {
 			locald := d
@@ -70,7 +70,7 @@ func (a *App) MeshAPIDevices(ids ...string) (map[int]*nycmesh.Device, error) {
 }
 
 // joinWithUISPData takes an unaugmented map of devices, and populates UISP fields
-func (a *App) joinWithUISPData(devs map[int]*nycmesh.Device) (map[int]*nycmesh.Device, error) {
+func (a *App) joinWithUISPData(devs map[int]*meshapi.Device) (map[int]*meshapi.Device, error) {
 	interval := "day"
 	sitesok, err := a.UISPAPI.Sites.GetSites(sites.NewGetSitesParams().WithDefaults(), nil)
 	if err != nil {

--- a/pkg/app/devices.go
+++ b/pkg/app/devices.go
@@ -28,11 +28,6 @@ func (a *App) UISPDevices() ([]*models.DeviceStatusOverview, error) {
 }
 
 func (a *App) MeshAPIDevices(ids ...string) (map[int]*meshapi.Device, error) {
-	nodes, err := a.MeshAPIClient.Nodes()
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch devices: %w", err)
-	}
-
 	idFilter := map[int]interface{}{}
 	for _, idarg := range ids {
 		n, err := strconv.Atoi(idarg)
@@ -40,6 +35,11 @@ func (a *App) MeshAPIDevices(ids ...string) (map[int]*meshapi.Device, error) {
 			return nil, fmt.Errorf("%s is not a valid device identifier: %w", idarg, err)
 		}
 		idFilter[n] = true
+	}
+
+	nodes, err := a.MeshAPINodes()
+	if err != nil {
+		return nil, err
 	}
 
 	devs := map[int]*meshapi.Device{}
@@ -57,14 +57,6 @@ func (a *App) MeshAPIDevices(ids ...string) (map[int]*meshapi.Device, error) {
 			devs[d.ID] = &locald
 		}
 	}
-
-	/*
-				modifiedDevs, err := a.joinWithUISPData(devs)
-				if err != nil {
-					return nil, fmt.Errorf("error joining uisp data with devices: %w", err)
-				}
-		    return modifiedDevs, nil
-	*/
 
 	return devs, nil
 }
@@ -122,34 +114,4 @@ func ByteCountIEC(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %ciB",
 		float64(b)/float64(div), "KMGTPE"[exp])
-}
-
-// TODO(gabe): implement me
-func (a *App) ListSectorsByFrequency() error {
-	params := devices.NewGetDevicesParams()
-	devs, err := a.UISPAPI.Devices.GetDevices(params, nil)
-	if err != nil {
-		return fmt.Errorf("unable to get devices: %w", err)
-	}
-	fmt.Printf("res: %+v\n", devs)
-	for _, d := range devs.Payload {
-		fmt.Printf("%+v\n", d)
-	}
-	return nil
-}
-
-// TODO(gabe): implement me
-func (a *App) SetSectorFrequency(frequency string, devids ...[]string) error {
-	log.Printf("setSectorFrequency called: freq:%s devs:%v\n", frequency, devids)
-
-	params := devices.NewGetDevicesParams()
-	devs, err := a.UISPAPI.Devices.GetDevices(params, nil)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("res: %+v\n", devs)
-	for _, d := range devs.Payload {
-		fmt.Printf("%+v\n", d)
-	}
-	return fmt.Errorf("TODO implement me")
 }

--- a/pkg/meshapi/api.go
+++ b/pkg/meshapi/api.go
@@ -69,6 +69,7 @@ func (c *Client) do(method, endpoint string, params map[string]string) (*http.Re
 }
 
 // GeoURI is a utility format helper to create a geo URI string from lat/lon/alt
+// TODO: find a better home for this?
 func GeoURI(lat float64, long float64, altMeters float64) string {
 	return fmt.Sprintf("geo:%f,%f,%.0f", lat, long, altMeters)
 }

--- a/pkg/meshapi/api.go
+++ b/pkg/meshapi/api.go
@@ -1,4 +1,4 @@
-package nycmesh
+package meshapi
 
 import (
 	"fmt"

--- a/pkg/meshapi/device.go
+++ b/pkg/meshapi/device.go
@@ -1,4 +1,4 @@
-package nycmesh
+package meshapi
 
 import (
 	"encoding/json"

--- a/pkg/meshapi/device.go
+++ b/pkg/meshapi/device.go
@@ -1,8 +1,6 @@
 package meshapi
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 )
 
@@ -44,23 +42,4 @@ func (s DevicesByID) Swap(i, j int) {
 
 func (s DevicesByID) Less(i, j int) bool {
 	return s[i].ID < s[j].ID
-}
-
-// Devices returns the list of Devices from NYCMesh API
-// TODO: should devices be cached/fetched as 1 block, or as individual entries?
-func (c *Client) Devices() (map[int]*Device, error) {
-	var body []byte
-	var err error
-
-	var devices []*Device
-	if err = json.Unmarshal(body, &devices); err != nil {
-		return nil, fmt.Errorf("unable to decode devices: %w\n%s", err, body)
-	}
-
-	m := map[int]*Device{}
-	for _, dev := range devices {
-		m[dev.ID] = dev
-	}
-
-	return m, nil
 }

--- a/pkg/meshapi/kml.go
+++ b/pkg/meshapi/kml.go
@@ -1,0 +1,17 @@
+package meshapi
+
+import (
+	"fmt"
+)
+
+func (c *Client) KML() ([]byte, error) {
+	var body []byte
+	var err error
+
+	body, err = c.do_body("GET", path+"/kml", map[string]string{})
+	if err != nil {
+		return nil, fmt.Errorf("Unable to fetch kml: %w", err)
+	}
+
+	return body, nil
+}

--- a/pkg/meshapi/node.go
+++ b/pkg/meshapi/node.go
@@ -1,4 +1,4 @@
-package nycmesh
+package meshapi
 
 import (
 	"encoding/json"

--- a/pkg/nycmesh/api.go
+++ b/pkg/nycmesh/api.go
@@ -1,14 +1,12 @@
 package nycmesh
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
 
-	uisp "github.com/byxorna/nycmesh-tool/generated/go/uisp/models"
 	"github.com/byxorna/nycmesh-tool/pkg/cache"
 )
 
@@ -26,72 +24,6 @@ type Client struct {
 	diskCache cache.DiskCache
 }
 
-// https://github.com/meshcenter/mesh-api/blob/master/migrations/1608616875404_base.js#L27
-type Node struct {
-	ID             int        `json:"id"`
-	Latitude       float64    `json:"lat"`
-	Longitude      float64    `json:"lng"`
-	AltitudeMeters float64    `json:"alt"`
-	Status         string     `json:"status"`
-	Location       string     `json:"location"`
-	Name           string     `json:"name"`
-	Notes          string     `json:"notes"`
-	Created        time.Time  `json:"create_date"`
-	Abandoned      *time.Time `json:"abandon_date,omitempty"`
-	BuildingID     int        `json:"building_id"`
-	Building       string     `json:"building"`
-	MemberID       int        `json:"member_id"`
-	Devices        []Device   `json:"devices"`
-}
-
-type Device struct {
-	ID             int        `json:"id"`
-	Latitude       float64    `json:"lat"`
-	Longitude      float64    `json:"lng"`
-	AltitudeMeters float64    `json:"alt"`
-	Azimuth        int        `json:"azimuth"`
-	Status         string     `json:"status"`
-	Name           string     `json:"name"`
-	SSID           string     `json:"ssid"`
-	Notes          string     `json:"notes"`
-	NodeID         int        `json:"node_id"`
-	Created        time.Time  `json:"create_date"`
-	Abandoned      *time.Time `json:"abandon_date,omitempty"`
-	Type           DeviceType `json:"type"`
-
-	// TODO
-	// State DeviceState
-}
-
-type DeviceType struct {
-	ID           int     `json:"id"`
-	Name         string  `json:"name"`
-	Manufacturer string  `json:"manufacturer"`
-	Range        float64 `json:"range"`
-	Width        float64 `json:"width"`
-}
-
-// TODO unused
-// DeviceState are where we keep additional properties we can discover from various
-// external sources, like UISP, airview tables, etc.
-type DeviceState struct {
-	UISPDevice *uisp.Device
-}
-
-type NodesByID []Node
-
-func (s NodesByID) Len() int {
-	return len(s)
-}
-
-func (s NodesByID) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s NodesByID) Less(i, j int) bool {
-	return s[i].ID < s[j].ID
-}
-
 func New() (*Client, error) {
 	dc, err := cache.NewDiskVCache()
 	if err != nil {
@@ -104,70 +36,6 @@ func New() (*Client, error) {
 		},
 		diskCache: dc,
 	}, nil
-}
-
-// Devices returns the list of Devices from NYCMesh API
-// TODO: should devices be cached/fetched as 1 block, or as individual entries?
-func (c *Client) Devices() (map[int]*Device, error) {
-	var body []byte
-	var err error
-
-	var devices []*Device
-	if err = json.Unmarshal(body, &devices); err != nil {
-		return nil, fmt.Errorf("unable to decode devices: %w\n%s", err, body)
-	}
-
-	m := map[int]*Device{}
-	for _, dev := range devices {
-		m[dev.ID] = dev
-	}
-
-	return m, nil
-}
-
-// TODO: this function should get cleaned up, we should not be storing
-// nodes.json as a single blob. Instead, store each node, and a list of node IDs.
-func (c *Client) Nodes(ids ...int) (map[int]Node, error) {
-	var body []byte
-	var err error
-
-	if !c.diskCache.Has("nodes") {
-		body, err := c.do_body("GET", path+"/nodes", map[string]string{})
-		if err != nil {
-			return nil, fmt.Errorf("Unable to fetch nodes: %w", err)
-		}
-
-		err = c.diskCache.Write("nodes", body)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	body, err = c.diskCache.Read("nodes")
-	if err != nil {
-		return nil, err
-	}
-
-	var nodes []Node
-	if err = json.Unmarshal(body, &nodes); err != nil {
-		return nil, fmt.Errorf("unable to decode nodes: %w\n%s", err, body)
-	}
-
-	idFilter := map[int]bool{}
-	for _, id := range ids {
-		idFilter[id] = true
-	}
-
-	m := map[int]Node{}
-	for _, node := range nodes {
-		if _, matchesFilter := idFilter[node.ID]; !matchesFilter && len(idFilter) > 0 {
-			// only return nodes that match provided filter if necessary
-			continue
-		}
-		m[node.ID] = node
-	}
-
-	return m, nil
 }
 
 func (c *Client) do_body(method, endpoint string, params map[string]string) ([]byte, error) {
@@ -198,4 +66,9 @@ func (c *Client) do(method, endpoint string, params map[string]string) (*http.Re
 	}
 	req.URL.RawQuery = q.Encode()
 	return c.Client.Do(req)
+}
+
+// GeoURI is a utility format helper to create a geo URI string from lat/lon/alt
+func GeoURI(lat float64, long float64, altMeters float64) string {
+	return fmt.Sprintf("geo:%f,%f,%.0f", lat, long, altMeters)
 }

--- a/pkg/nycmesh/device.go
+++ b/pkg/nycmesh/device.go
@@ -1,0 +1,66 @@
+package nycmesh
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type Device struct {
+	ID             int        `json:"id"`
+	Latitude       float64    `json:"lat"`
+	Longitude      float64    `json:"lng"`
+	AltitudeMeters float64    `json:"alt"`
+	Azimuth        int        `json:"azimuth"`
+	Status         string     `json:"status"`
+	Name           string     `json:"name"`
+	SSID           string     `json:"ssid"`
+	Notes          string     `json:"notes"`
+	NodeID         int        `json:"node_id"`
+	Created        time.Time  `json:"create_date"`
+	Abandoned      *time.Time `json:"abandon_date,omitempty"`
+	Type           DeviceType `json:"type"`
+
+	// TODO
+}
+
+type DeviceType struct {
+	ID           int     `json:"id"`
+	Name         string  `json:"name"`
+	Manufacturer string  `json:"manufacturer"`
+	Range        float64 `json:"range"`
+	Width        float64 `json:"width"`
+}
+
+type DevicesByID []Device
+
+func (s DevicesByID) Len() int {
+	return len(s)
+}
+
+func (s DevicesByID) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s DevicesByID) Less(i, j int) bool {
+	return s[i].ID < s[j].ID
+}
+
+// Devices returns the list of Devices from NYCMesh API
+// TODO: should devices be cached/fetched as 1 block, or as individual entries?
+func (c *Client) Devices() (map[int]*Device, error) {
+	var body []byte
+	var err error
+
+	var devices []*Device
+	if err = json.Unmarshal(body, &devices); err != nil {
+		return nil, fmt.Errorf("unable to decode devices: %w\n%s", err, body)
+	}
+
+	m := map[int]*Device{}
+	for _, dev := range devices {
+		m[dev.ID] = dev
+	}
+
+	return m, nil
+}

--- a/pkg/nycmesh/node.go
+++ b/pkg/nycmesh/node.go
@@ -1,9 +1,84 @@
 package nycmesh
 
 import (
+	"encoding/json"
 	"fmt"
+	"time"
 )
 
-func GeoURI(lat float64, long float64, altMeters float64) string {
-	return fmt.Sprintf("geo:%f,%f,%.0f", lat, long, altMeters)
+// https://github.com/meshcenter/mesh-api/blob/master/migrations/1608616875404_base.js#L27
+type Node struct {
+	ID             int        `json:"id"`
+	Latitude       float64    `json:"lat"`
+	Longitude      float64    `json:"lng"`
+	AltitudeMeters float64    `json:"alt"`
+	Status         string     `json:"status"`
+	Location       string     `json:"location"`
+	Name           string     `json:"name"`
+	Notes          string     `json:"notes"`
+	Created        time.Time  `json:"create_date"`
+	Abandoned      *time.Time `json:"abandon_date,omitempty"`
+	BuildingID     int        `json:"building_id"`
+	Building       string     `json:"building"`
+	MemberID       int        `json:"member_id"`
+	Devices        []Device   `json:"devices"`
+}
+
+type NodesByID []Node
+
+func (s NodesByID) Len() int {
+	return len(s)
+}
+
+func (s NodesByID) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s NodesByID) Less(i, j int) bool {
+	return s[i].ID < s[j].ID
+}
+
+// TODO: this function should get cleaned up, we should not be storing
+// nodes.json as a single blob. Instead, store each node, and a list of node IDs.
+func (c *Client) Nodes(ids ...int) (map[int]Node, error) {
+	var body []byte
+	var err error
+
+	if !c.diskCache.Has("nodes") {
+		body, err := c.do_body("GET", path+"/nodes", map[string]string{})
+		if err != nil {
+			return nil, fmt.Errorf("Unable to fetch nodes: %w", err)
+		}
+
+		err = c.diskCache.Write("nodes", body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	body, err = c.diskCache.Read("nodes")
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []Node
+	if err = json.Unmarshal(body, &nodes); err != nil {
+		return nil, fmt.Errorf("unable to decode nodes: %w\n%s", err, body)
+	}
+
+	idFilter := map[int]bool{}
+	for _, id := range ids {
+		idFilter[id] = true
+	}
+
+	m := map[int]Node{}
+	for _, node := range nodes {
+		if _, matchesFilter := idFilter[node.ID]; !matchesFilter && len(idFilter) > 0 {
+			// only return nodes that match provided filter if necessary
+			continue
+		}
+		m[node.ID] = node
+	}
+
+	return m, nil
 }


### PR DESCRIPTION
Reorganizes the `meshapi` package for a bit more sanity, and removed the double-use of diskv in both `meshapi` and `app` packages (that was confusing). This should be no change in functionality, but I added a simple `mesh kml` command just for fun.