### PR TITLE
daemon: dfs event detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ At the moment, the tool is pretty sparse. It provides the top level `nycmesh-too
   - `device` - Display devices from https://api.nycmesh.net/v1/nodes
 - `map` - Open up nodes on a map from the command line
 - `cache` - manipulate a simple on-disk cache for things like API responses, for offline access to inventory
+- `daemon` - launch a daemon to do stuff (current features include:)
+  - Sector DFS watch: notify hub slack channels when DFS events occur
 - `experiment` - Experimental commands. Here be dragons!
   - `devices` - display fused device data, created by joining UISP data with mesh-api data. Useful for further `jq` processing.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ uisp:
   scheme: https
   skip-verify-tls: false # true needed for self-signed certs
   debug: true
+
+# note: the slack key is optional, and only useful if you are running `daemon`
+# slack:
+#   token: "put your bot token here"
 ```
 
 ## UISP API Commands

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ At the moment, the tool is pretty sparse. It provides the top level `nycmesh-too
 - `map` - Open up nodes on a map from the command line
 - `cache` - manipulate a simple on-disk cache for things like API responses, for offline access to inventory
 - `daemon` - launch a daemon to do stuff (current features include:)
-  - Sector DFS watch: notify hub slack channels when DFS events occur
+  - `--dfs-event-detection`: monitor sectors for DFS events, and notify relevant channels
 - `experiment` - Experimental commands. Here be dragons!
   - `devices` - display fused device data, created by joining UISP data with mesh-api data. Useful for further `jq` processing.
 - `watch`

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/byxorna/nycmesh-tool/pkg/app"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -34,6 +35,8 @@ var (
 )
 
 func init() {
-	// TODO: add pidfile, etc type flags?
+	daemonCmd.Flags().Bool("dfs-event-detection", true, "enable DFS event detection feature")
+	viper.BindPFlag("feature.dfs-event-detection", daemonCmd.Flags().Lookup("dfs-event-detection"))
+
 	rootCmd.AddCommand(daemonCmd)
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/byxorna/nycmesh-tool/pkg/app"
+	"github.com/spf13/cobra"
+)
+
+var (
+	daemonCmd = &cobra.Command{
+		Use:   "daemon",
+		Short: "launch a daemon",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			a, err := app.New(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			log.Print("launching daemon...")
+			errs := a.RunDaemon()
+			if len(errs) > 0 {
+				log.Printf("daemon reported %d errors", len(errs))
+
+				// for now, just return the first error to kill the program
+				// as the errors shouild have already been logged as they were intercepted
+				return errs[0]
+
+			}
+			return nil
+		},
+	}
+)
+
+func init() {
+	// TODO: add pidfile, etc type flags?
+	rootCmd.AddCommand(daemonCmd)
+}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"log"
 
 	"github.com/byxorna/nycmesh-tool/pkg/app"
@@ -18,7 +19,7 @@ var (
 			}
 
 			log.Print("launching daemon...")
-			errs := a.RunDaemon()
+			errs := a.RunDaemon(context.Background())
 			if len(errs) > 0 {
 				log.Printf("daemon reported %d errors", len(errs))
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -37,6 +37,7 @@ var (
 func init() {
 	daemonCmd.Flags().Bool("dfs-event-detection", true, "enable DFS event detection feature")
 	viper.BindPFlag("feature.dfs-event-detection", daemonCmd.Flags().Lookup("dfs-event-detection"))
-
+	daemonCmd.Flags().String("slack-token", "slack.token", "specify the slack.token to connect with slack")
+	viper.BindPFlag("slack.token", daemonCmd.Flags().Lookup("slack-token"))
 	rootCmd.AddCommand(daemonCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -42,6 +43,8 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/slack-go/slack v0.10.1 // indirect
 	github.com/spf13/afero v1.7.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,7 @@ github.com/go-openapi/validate v0.20.3/go.mod h1:goDdqVGiigM3jChcrYJxD2joalke3ZX
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -347,6 +348,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
@@ -482,6 +485,7 @@ github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsU
 github.com/peterbourgon/diskv/v3 v3.0.1/go.mod h1:kJ5Ny7vLdARGU3WUuy6uzO6T0nb/2gWcT1JiBvRmb5o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -513,6 +517,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/slack-go/slack v0.10.1 h1:BGbxa0kMsGEvLOEoZmYs8T1wWfoZXwmQFBb6FgYCXUA=
+github.com/slack-go/slack v0.10.1/go.mod h1:wWL//kk0ho+FcQXcBTmEafUI5dz4qz5f4mMk8oIkioQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -2,74 +2,140 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"regexp"
+	"sort"
 	"sync"
 	"time"
 )
 
-func (a *App) coroutineDFSWatch(ctx context.Context) error {
-	/*
-	   {
-	     "device": {
-	       "authorized": true,
-	       "category": "wireless",
-	       "displayName": "nycmesh-sn3-south",
-	       "firmwareVersion": "8.7.7",
-	       "id": "62351c24-d13b-4e5f-92d9-a39492e718c0",
-	       "ip": "10.xxxx/24",
-	       "mac": "b4:fb:xxx:5c",
-	       "model": "LAP-120",
-	       "modelName": "LiteAP AC",
-	       "name": "nycmesh-sn3-south",
-	       "platformId": "WA",
-	       "platformName": "WA",
-	       "site": {
-	         "id": "xxxx",
-	         "name": "SN3 - 713",
-	         "parent": {
-	           "id": "xxxx",
-	           "name": "Degraw - 2282",
-	           "parent": null,
-	           "status": "active",
-	           "type": "site"
-	         },
-	         "status": "active",
-	         "type": "site"
-	       },
-	       "started": "0001-01-01T00:00:00.000Z",
-	       "type": "airMax",
-	       "updated": "0001-01-01T00:00:00.000Z"
-	     },
-	     "deviceMetadata": {
-	       "alias": "nycmesh-sn3-south"
-	     },
-	     "id": "49205812-6bfe-46b8-8b1a-4b16c0581c12",
-	     "level": "error",
-	     "message": "Device nycmesh-sn3-south main radio changed frequency due to DFS detection",
-	     "site": {
-	       "id": "fd468966-adc9-4f28-b72d-4d97891d6734",
-	       "name": "SN3 - 713",
-	       "parent": {
-	         "id": "d0b4cf55-15a7-4e60-ba4f-973ef74b5d5e",
-	         "name": "Degraw - 2282",
-	         "parent": null,
-	         "status": "active",
-	         "type": "site"
-	       },
-	       "status": "active",
-	       "type": "site"
-	     },
-	     "tags": [
-	       "device",
-	       "device-state"
-	     ],
-	     "timestamp": "2022-02-03T23:11:03.900Z"
-	   },
-	*/
+var (
+	daemonWatchFailureBackoff = time.Second * 10
+)
+
+/* DFS Event log example
+
+{
+      "device": {
+      "authorized": true,
+      "category": "wireless",
+      "displayName": "nycmesh-sn3-south",
+      "firmwareVersion": "8.7.7",
+      "id": "62351c24-d13b-4e5f-92d9-a39492e718c0",
+      "ip": "10.70.88.116/24",
+      "mac": "b4:fb:e4:5a:5c:5c",
+      "model": "LAP-120",
+      "modelName": "LiteAP AC",
+      "name": "nycmesh-sn3-south",
+      "platformId": "WA",
+      "platformName": "WA",
+      "site": {
+        "id": "fd468966-adc9-4f28-b72d-4d97891d6734",
+        "name": "SN3 - 713",
+        "parent": {
+          "id": "d0b4cf55-15a7-4e60-ba4f-973ef74b5d5e",
+          "name": "Degraw - 2282",
+          "parent": null,
+          "status": "active",
+          "type": "site"
+        },
+        "status": "active",
+        "type": "site"
+      },
+      "started": "0001-01-01T00:00:00.000Z",
+      "type": "airMax",
+      "updated": "0001-01-01T00:00:00.000Z"
+    },
+    "deviceMetadata": {
+      "alias": "nycmesh-sn3-south"
+    },
+    "id": "49205812-6bfe-46b8-8b1a-4b16c0581c12",
+    "level": "error",
+    "message": "Device nycmesh-sn3-south main radio changed frequency due to DFS detection",
+    "site": {
+      "id": "fd468966-adc9-4f28-b72d-4d97891d6734",
+      "name": "SN3 - 713",
+      "parent": {
+        "id": "d0b4cf55-15a7-4e60-ba4f-973ef74b5d5e",
+        "name": "Degraw - 2282",
+        "parent": null,
+        "status": "active",
+        "type": "site"
+      },
+      "status": "active",
+      "type": "site"
+    },
+    "tags": [
+      "device",
+      "device-state"
+    ],
+    "timestamp": "2022-02-03T23:11:03.900Z"
+  }
+*/
+
+func (a *App) coroutineLogWatch(ctx context.Context) error {
 	log.Printf("dfs watch: start")
-	return fmt.Errorf("implement DFS watching")
-	time.Sleep(15 * time.Second)
+
+	ctxDone := ctx.Done()
+	wg := sync.WaitGroup{}
+	rawLogsCh := make(chan LogEvent, 10)
+	dfsEventCh := make(chan LogEvent)
+
+	// start up the log producer, which pushes events into rawLogsCh
+	wg.Add(1)
+	go func() {
+		for {
+			select {
+			case <-ctxDone:
+				break
+			default:
+				// we start watching logs since 24h ago, so we catch any recent events
+				if err := a.WatchLogs(ctx, time.Now().Add(-(time.Hour * 24)), rawLogsCh); err != nil {
+					log.Printf("unable to watch logs: %w", err)
+					log.Printf("retrying log watch after %s backoff", daemonWatchFailureBackoff)
+					time.Sleep(daemonWatchFailureBackoff)
+				}
+			}
+		}
+		wg.Done()
+	}()
+
+	// start up the DFS detection consumer, that filters events for DFS events, and emits them to dfsEventCh
+	wg.Add(1)
+	go func() {
+		dfsMessageRegex := regexp.MustCompile(`\bchanged frequency due to DFS detection\b`)
+		//dfsMessageRegex := regexp.MustCompile(`\bhas been disconnected\b`)
+		for {
+			select {
+			case <-ctxDone:
+				break
+			case rawLog := <-rawLogsCh:
+				t := rawLog.Tags
+				sort.Strings(t)
+
+				if rawLog.Message != nil && dfsMessageRegex.MatchString(*rawLog.Message) && sort.SearchStrings(t, "device-state") != len(t) {
+					dfsEventCh <- rawLog
+				}
+			}
+		}
+		wg.Done()
+	}()
+
+	// read from dfsEventCh, log events as we see them
+	wg.Add(1)
+	go func() {
+		for {
+			select {
+			case <-ctxDone:
+				break
+			case dfsEvent := <-dfsEventCh:
+				log.Printf("DFS event detected at nn:%d: %s", dfsEvent.NN, *dfsEvent.Message)
+			}
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
 	log.Printf("dfs watch: end")
 	return nil
 }
@@ -77,7 +143,7 @@ func (a *App) coroutineDFSWatch(ctx context.Context) error {
 func (a *App) RunDaemon(daemonCtx context.Context) (errs []error) {
 	coroutines := []func(context.Context) error{
 		// NOTE(gabe): define all tasks that should run within the context of the daemon here
-		a.coroutineDFSWatch,
+		a.coroutineLogWatch,
 	}
 
 	errCh := make(chan error)

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+func (a *App) RunDaemon() (errs []error) {
+	coroutines := []func() error{
+		func() error {
+			time.Sleep(10 * time.Second)
+			return fmt.Errorf("BOOM")
+		},
+	}
+	errCh := make(chan error)
+	wgDone := make(chan bool)
+
+	// TODO: coroutines should map into a channel of errors
+	wg := sync.WaitGroup{}
+	for i, cr := range coroutines {
+		i := i // local variable, so we dont lose track of which coroutine is which
+		wg.Add(1)
+		go func(routine func() error) {
+			err := routine()
+			if err != nil {
+				log.Printf("daemon coroutine %d failed: %s", i, err.Error())
+				errCh <- err
+			}
+			wg.Done()
+		}(cr)
+	}
+
+	go func() {
+		wg.Wait()
+		close(wgDone) // make sure to close the done channel, so we know when to wrap up
+	}()
+
+	select {
+	case <-wgDone:
+		break
+	case err := <-errCh:
+		errs = append(errs, err)
+	}
+
+	return errs
+}

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -92,7 +92,7 @@ func (a *App) coroutineLogWatch(ctx context.Context) error {
 			default:
 				log.Printf("initial log query window is %s", initialQueryPeriod)
 				if err := a.WatchLogs(ctx, time.Now().Add(-initialQueryPeriod), rawLogsCh); err != nil {
-					log.Printf("unable to watch logs: %w", err)
+					log.Printf("unable to watch logs: %s", err.Error())
 					log.Printf("retrying log watch after %s backoff", daemonWatchFailureBackoff)
 					time.Sleep(daemonWatchFailureBackoff)
 				}
@@ -120,7 +120,7 @@ func (a *App) coroutineLogWatch(ctx context.Context) error {
 				}
 			}
 		}
-		log.Printf("dfs watch: end")
+
 		wg.Done()
 	}()
 

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -9,6 +9,64 @@ import (
 )
 
 func (a *App) coroutineDFSWatch(ctx context.Context) error {
+	/*
+	   {
+	     "device": {
+	       "authorized": true,
+	       "category": "wireless",
+	       "displayName": "nycmesh-sn3-south",
+	       "firmwareVersion": "8.7.7",
+	       "id": "62351c24-d13b-4e5f-92d9-a39492e718c0",
+	       "ip": "10.xxxx/24",
+	       "mac": "b4:fb:xxx:5c",
+	       "model": "LAP-120",
+	       "modelName": "LiteAP AC",
+	       "name": "nycmesh-sn3-south",
+	       "platformId": "WA",
+	       "platformName": "WA",
+	       "site": {
+	         "id": "xxxx",
+	         "name": "SN3 - 713",
+	         "parent": {
+	           "id": "xxxx",
+	           "name": "Degraw - 2282",
+	           "parent": null,
+	           "status": "active",
+	           "type": "site"
+	         },
+	         "status": "active",
+	         "type": "site"
+	       },
+	       "started": "0001-01-01T00:00:00.000Z",
+	       "type": "airMax",
+	       "updated": "0001-01-01T00:00:00.000Z"
+	     },
+	     "deviceMetadata": {
+	       "alias": "nycmesh-sn3-south"
+	     },
+	     "id": "49205812-6bfe-46b8-8b1a-4b16c0581c12",
+	     "level": "error",
+	     "message": "Device nycmesh-sn3-south main radio changed frequency due to DFS detection",
+	     "site": {
+	       "id": "fd468966-adc9-4f28-b72d-4d97891d6734",
+	       "name": "SN3 - 713",
+	       "parent": {
+	         "id": "d0b4cf55-15a7-4e60-ba4f-973ef74b5d5e",
+	         "name": "Degraw - 2282",
+	         "parent": null,
+	         "status": "active",
+	         "type": "site"
+	       },
+	       "status": "active",
+	       "type": "site"
+	     },
+	     "tags": [
+	       "device",
+	       "device-state"
+	     ],
+	     "timestamp": "2022-02-03T23:11:03.900Z"
+	   },
+	*/
 	log.Printf("dfs watch: start")
 	return fmt.Errorf("implement DFS watching")
 	time.Sleep(15 * time.Second)

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -1,19 +1,27 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
 	"time"
 )
 
-func (a *App) RunDaemon() (errs []error) {
-	coroutines := []func() error{
-		func() error {
-			time.Sleep(10 * time.Second)
-			return fmt.Errorf("BOOM")
-		},
+func (a *App) coroutineDFSWatch(ctx context.Context) error {
+	log.Printf("dfs watch: start")
+	return fmt.Errorf("implement DFS watching")
+	time.Sleep(15 * time.Second)
+	log.Printf("dfs watch: end")
+	return nil
+}
+
+func (a *App) RunDaemon(daemonCtx context.Context) (errs []error) {
+	coroutines := []func(context.Context) error{
+		// NOTE(gabe): define all tasks that should run within the context of the daemon here
+		a.coroutineDFSWatch,
 	}
+
 	errCh := make(chan error)
 	wgDone := make(chan bool)
 
@@ -22,8 +30,8 @@ func (a *App) RunDaemon() (errs []error) {
 	for i, cr := range coroutines {
 		i := i // local variable, so we dont lose track of which coroutine is which
 		wg.Add(1)
-		go func(routine func() error) {
-			err := routine()
+		go func(routine func(context.Context) error) {
+			err := routine(daemonCtx)
 			if err != nil {
 				log.Printf("daemon coroutine %d failed: %s", i, err.Error())
 				errCh <- err

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -74,7 +74,6 @@ var (
 */
 
 func (a *App) coroutineLogWatch(ctx context.Context) error {
-	log.Printf("dfs watch: start")
 
 	ctxDone := ctx.Done()
 	wg := sync.WaitGroup{}
@@ -104,6 +103,7 @@ func (a *App) coroutineLogWatch(ctx context.Context) error {
 	wg.Add(1)
 	go func() {
 		dfsMessageRegex := regexp.MustCompile(`\bchanged frequency due to DFS detection\b`)
+		log.Printf("watching for DFS events with `%v`", dfsMessageRegex)
 		//dfsMessageRegex := regexp.MustCompile(`\bhas been disconnected\b`)
 		for {
 			select {
@@ -118,6 +118,7 @@ func (a *App) coroutineLogWatch(ctx context.Context) error {
 				}
 			}
 		}
+		log.Printf("dfs watch: end")
 		wg.Done()
 	}()
 
@@ -136,7 +137,6 @@ func (a *App) coroutineLogWatch(ctx context.Context) error {
 	}()
 
 	wg.Wait()
-	log.Printf("dfs watch: end")
 	return nil
 }
 


### PR DESCRIPTION
initial `daemon` support. The daemon will poll for logs in UISP, and notify via `stdout` when a DFS event is detected.

As this is a lot of infrastructure being committed here, I opted to keep this PR shorter, and implement the hub slack channel notification in another PR.