### PR TITLE
[WIP] User-Agent setting for UISP http client

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,8 +1,16 @@
 package version
 
+import (
+	"fmt"
+)
+
 var (
 	GitCommit string = "unknown"
 	GitBranch string = "unknown"
 	Release   string
 	BuildDate string
 )
+
+func UserAgent() string {
+	return fmt.Sprintf("nycmesh-tool/%s-%s", Release, GitCommit)
+}


### PR DESCRIPTION
I am trying to make goswagger's generated UISP client use a specific User-Agent (to help identify which build is hitting UISP via access logs). Unfortunately, so far I have been unable to figure out which is the correct application of replacing the transport of the runtime with a custom `http.RoundTripper` that _should_ (but for some reason does not) set the header on every request.


This PR needs love ❤️ 