### PR TITLE
daemon: Slack client for posting DFS events

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -30,3 +30,13 @@ Business logic lives in `app/`, command line flag processing lives in `cmd/`.
 # Releases
 
 See [./RELEASES.md](RELEASES.md)
+
+# Random Notes
+
+## Fixing/extending generated code
+
+This project uses cobra/viper for flag and config processing, as does the goswagger generated code for UISP's CLI (`generated/go/uisp`). To inject our custom hacks into this generated code, see `internal/uisp/cli/custom.go` which is linked in at `generated/go/uisp/cli/custom.go`. 
+
+TODO: there are some manual changes needed to make the generated go-swagger code compile. Document the patchsets, and/or automate them!
+
+- `Sfp+1` and `Sfp1`: the generator templates just drop `+` from identifiers, so this creates a lot of duplicate functions and vars.

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -36,7 +36,11 @@ var (
 
 func init() {
 	daemonCmd.Flags().Bool("dfs-event-detection", true, "enable DFS event detection feature")
-	viper.BindPFlag("feature.dfs-event-detection", daemonCmd.Flags().Lookup("dfs-event-detection"))
+	viper.BindPFlag("daemon.dfs-event-detection", daemonCmd.Flags().Lookup("dfs-event-detection"))
+
+	daemonCmd.Flags().Bool("enable-slack", false, "enable Slack integration for the daemon")
+	viper.BindPFlag("daemon.enable-slack", daemonCmd.Flags().Lookup("enable-slack"))
+
 	daemonCmd.Flags().String("slack-token", "slack.token", "specify the slack.token to connect with slack")
 	viper.BindPFlag("slack.token", daemonCmd.Flags().Lookup("slack-token"))
 	rootCmd.AddCommand(daemonCmd)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -10,11 +10,15 @@ import (
 	"github.com/byxorna/nycmesh-tool/pkg/cache"
 	"github.com/byxorna/nycmesh-tool/pkg/meshapi"
 	"github.com/byxorna/nycmesh-tool/pkg/version"
+	"github.com/slack-go/slack"
 	"github.com/spf13/cobra"
 )
 
 type App struct {
 	*client.UISPAPI
+
+	Slack *slack.Client
+
 	MeshAPIClient *meshapi.Client
 
 	// TODO: wire this up as a general caching layer, instead of if being in meshapi.Client?
@@ -43,6 +47,10 @@ func New(cmd *cobra.Command, args []string) (*App, error) {
 		return nil, fmt.Errorf("unable to create nycmesh client: %w", err)
 	}
 	a.MeshAPIClient = nycmeshClient
+
+	if a.config.EnableSlack {
+		a.Slack = slack.New(a.config.slackToken)
+	}
 	return &a, nil
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -19,10 +19,12 @@ type App struct {
 
 	// TODO: wire this up as a general caching layer, instead of if being in meshapi.Client?
 	diskCache cache.DiskCache
+
+	config *Config
 }
 
 func New(cmd *cobra.Command, args []string) (*App, error) {
-	a := App{}
+	a := App{config: NewConfig()}
 
 	diskCache, err := cache.NewDiskVCache()
 	if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -28,7 +28,13 @@ type App struct {
 }
 
 func New(cmd *cobra.Command, args []string) (*App, error) {
-	a := App{config: NewConfig()}
+	a := App{}
+
+	cfg, err := NewConfig()
+	if err != nil {
+		return nil, err
+	}
+	a.config = cfg
 
 	diskCache, err := cache.NewDiskVCache()
 	if err != nil {
@@ -48,8 +54,8 @@ func New(cmd *cobra.Command, args []string) (*App, error) {
 	}
 	a.MeshAPIClient = nycmeshClient
 
-	if a.config.EnableSlack {
-		a.Slack = slack.New(a.config.slackToken)
+	if a.config.Daemon.EnableSlack {
+		a.Slack = slack.New(a.config.Slack.token)
 	}
 	return &a, nil
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -1,25 +1,44 @@
 package app
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/viper"
+)
 
 type Config struct {
-	slackToken   string
-	outputFormat string
-	DaemonConfig
+	Core   CoreConfig   `json:"core"`
+	Slack  SlackConfig  `json:"slack"`
+	Daemon DaemonConfig `json:"daemon"`
+}
+
+type SlackConfig struct {
+	token string `json:"token"`
+}
+
+type CoreConfig struct {
+	OutputFormat string `json:"format"`
 }
 
 type DaemonConfig struct {
-	DFSEventDetection bool
-	EnableSlack       bool
+	DFSEventDetection bool `json:"dfs-event-detection"`
+	EnableSlack       bool `json:"enable-slack"`
 }
 
-func NewConfig() *Config {
-	return &Config{
-		outputFormat: viper.GetString("core.format"),
-		slackToken:   viper.GetString("slack.token"),
-		DaemonConfig: DaemonConfig{
+func NewConfig() (*Config, error) {
+	// TODO: there is surely a more clever way to get this struct populated via
+	// viper.Unmarshal, but I cannot be troubled to figure out the proper struct tags
+	// or why yaml bugs like https://github.com/spf13/viper/issues/338 matter
+	cfg := &Config{
+		Core: CoreConfig{
+			OutputFormat: viper.GetString("core.format"),
+		},
+		Slack: SlackConfig{
+			token: viper.GetString("slack.token"),
+		},
+		Daemon: DaemonConfig{
 			DFSEventDetection: viper.GetBool("daemon.dfs-event-detection"),
 			EnableSlack:       viper.GetBool("daemon.enable-slack"),
 		},
 	}
+
+	return cfg, nil
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -1,0 +1,25 @@
+package app
+
+import "github.com/spf13/viper"
+
+type Config struct {
+	slackToken   string
+	outputFormat string
+	DaemonConfig
+}
+
+type DaemonConfig struct {
+	DFSEventDetection bool
+	EnableSlack       bool
+}
+
+func NewConfig() *Config {
+	return &Config{
+		outputFormat: viper.GetString("core.format"),
+		slackToken:   viper.GetString("slack.token"),
+		DaemonConfig: DaemonConfig{
+			DFSEventDetection: viper.GetBool("daemon.dfs-event-detection"),
+			EnableSlack:       viper.GetBool("daemon.enable-slack"),
+		},
+	}
+}

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -13,6 +13,172 @@ var (
 	daemonWatchFailureBackoff = time.Second * 10
 )
 
+func (a *App) startLogProducer(ctx context.Context, wg *sync.WaitGroup, ch chan<- LogEvent) {
+	// start up the log producer, which pushes events into ch
+	wg.Add(1)
+	ctxDone := ctx.Done()
+
+	initialQueryPeriod := (time.Hour * 48)
+	log.Printf("bootstrapping by fetching logs %s old", initialQueryPeriod)
+
+	go func() {
+		defer func() {
+			close(ch)
+			wg.Done()
+		}()
+		for {
+			select {
+			case <-ctxDone:
+				break
+			default:
+				if err := a.WatchLogs(ctx, time.Now().Add(-initialQueryPeriod), ch); err != nil {
+					log.Printf("unable to watch logs: %s", err.Error())
+					log.Printf("retrying log watch after %s backoff", daemonWatchFailureBackoff)
+					time.Sleep(daemonWatchFailureBackoff)
+				}
+			}
+		}
+	}()
+}
+func (a *App) startLogConsumerMultiplexer(ctx context.Context, wg *sync.WaitGroup, srcCh <-chan LogEvent, numChannelsToMultiplexTo int) []chan LogEvent {
+	// create a multiplexer, so for each consumer that cares about logs, we make a new channel and send
+	// each log to each consumer
+	wg.Add(1)
+	ctxDone := ctx.Done()
+
+	downstreamChannels := make([]chan LogEvent, numChannelsToMultiplexTo)
+	for i := range downstreamChannels {
+		downstreamChannels[i] = make(chan LogEvent)
+	}
+
+	go func() {
+		defer func() {
+			for _, ch := range downstreamChannels {
+				close(ch)
+			}
+			wg.Done()
+		}()
+
+		for {
+			select {
+			case <-ctxDone:
+				break
+			case evt := <-srcCh:
+				// multiplex this log to all our downstreamChannels
+				for _, consumerCh := range downstreamChannels {
+					consumerCh <- evt
+				}
+			}
+		}
+	}()
+
+	return downstreamChannels
+}
+
+func (a *App) logConsumerDFSEventDetector(ctx context.Context, wg *sync.WaitGroup, logsCh <-chan LogEvent) {
+	dfsEventCh := make(chan LogEvent)
+	// start up the DFS detection consumer, that filters events for DFS events, and emits them to dfsEventCh
+	wg.Add(1)
+	ctxDone := ctx.Done()
+	go func() {
+		defer func() {
+			close(dfsEventCh)
+			wg.Done()
+		}()
+
+		dfsMessageRegex := regexp.MustCompile(`\bchanged frequency due to DFS detection\b`)
+		//dfsMessageRegex := regexp.MustCompile(`\bhas been disconnected\b`)
+		log.Printf("watching for DFS events with `%v`", dfsMessageRegex)
+		for {
+			select {
+			case <-ctxDone:
+				break
+			case rawLog := <-logsCh:
+				t := rawLog.Tags
+				sort.Strings(t)
+
+				if rawLog.Message != nil && dfsMessageRegex.MatchString(*rawLog.Message) { // && sort.SearchStrings(t, "device-state") != len(t) {
+					dfsEventCh <- rawLog
+				}
+			}
+		}
+
+	}()
+
+	// read from dfsEventCh, log events as we see them
+	// TODO: this is where we will bolt in the slack support for notifying channels when events are detected
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctxDone:
+				break
+			case dfsEvent := <-dfsEventCh:
+				log.Printf("DFS event detected at nn:%d on %s: %s", dfsEvent.NN, dfsEvent.Timestamp, *dfsEvent.Message)
+			}
+		}
+	}()
+}
+
+func (a *App) coroutineLogWatch(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	logFountain := make(chan LogEvent, 10)
+
+	logConsumers := []func(context.Context, *sync.WaitGroup, <-chan LogEvent){}
+	if a.config.DaemonConfig.DFSEventDetection {
+		logConsumers = append(logConsumers, a.logConsumerDFSEventDetector)
+	}
+
+	a.startLogProducer(ctx, &wg, logFountain)
+	outputChannels := a.startLogConsumerMultiplexer(ctx, &wg, logFountain, len(logConsumers))
+	for i, startCoroutine := range logConsumers {
+		// create the log watchers, giving them their own channel to listen on for logs
+		startCoroutine(ctx, &wg, outputChannels[i])
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (a *App) RunDaemon(daemonCtx context.Context) (errs []error) {
+	coroutines := []func(context.Context) error{
+		a.coroutineLogWatch,
+	}
+
+	errCh := make(chan error)
+	wgDone := make(chan bool)
+
+	// TODO: coroutines should map into a channel of errors
+	wg := sync.WaitGroup{}
+	for i, cr := range coroutines {
+		i := i // local variable, so we dont lose track of which coroutine is which
+		wg.Add(1)
+		go func(routine func(context.Context) error) {
+			err := routine(daemonCtx)
+			if err != nil {
+				log.Printf("daemon coroutine %d failed: %s", i, err.Error())
+				errCh <- err
+			}
+			wg.Done()
+		}(cr)
+	}
+
+	go func() {
+		wg.Wait()
+		close(wgDone) // make sure to close the done channel, so we know when to wrap up
+	}()
+
+	select {
+	case <-wgDone:
+		break
+	case err := <-errCh:
+		errs = append(errs, err)
+	}
+
+	return errs
+}
+
 /* DFS Event log example
 
 {
@@ -72,164 +238,3 @@ var (
     "timestamp": "2022-02-03T23:11:03.900Z"
   }
 */
-
-func (a *App) coroutineLogWatch(ctx context.Context) error {
-	wg := sync.WaitGroup{}
-	logFountain := make(chan LogEvent, 10)
-	logConsumerChannels := map[string]chan LogEvent{}
-
-	initialQueryPeriod := (time.Hour * 24 * 2)
-
-	startLogProducer := func(ctx context.Context, wg *sync.WaitGroup, ch chan<- LogEvent) {
-		// start up the log producer, which pushes events into ch
-		wg.Add(1)
-		ctxDone := ctx.Done()
-
-		go func() {
-			for {
-				select {
-				case <-ctxDone:
-					break
-				default:
-					log.Printf("initial log query window is %s", initialQueryPeriod)
-					if err := a.WatchLogs(ctx, time.Now().Add(-initialQueryPeriod), ch); err != nil {
-						log.Printf("unable to watch logs: %s", err.Error())
-						log.Printf("retrying log watch after %s backoff", daemonWatchFailureBackoff)
-						time.Sleep(daemonWatchFailureBackoff)
-					}
-				}
-			}
-
-			close(ch)
-			wg.Done()
-		}()
-	}
-
-	startLogConsumerMultiplexer := func(ctx context.Context, wg *sync.WaitGroup, srcCh <-chan LogEvent) {
-		// create a multiplexer, so for each consumer that cares about logs, we make a new channel and send
-		// each log to each consumer
-		wg.Add(1)
-		ctxDone := ctx.Done()
-
-		go func() {
-			defer func() {
-				for _, ch := range logConsumerChannels {
-					close(ch)
-				}
-				wg.Done()
-			}()
-
-			for {
-				select {
-				case <-ctxDone:
-					break
-				case evt := <-srcCh:
-					// multiplex this log to all our logConsumerChannels
-					for _, consumerCh := range logConsumerChannels {
-						consumerCh <- evt
-					}
-				}
-			}
-		}()
-	}
-
-	createDFSEventDetector := func(wg *sync.WaitGroup, logsCh <-chan LogEvent) {
-		dfsEventCh := make(chan LogEvent)
-		// start up the DFS detection consumer, that filters events for DFS events, and emits them to dfsEventCh
-		wg.Add(1)
-		ctxDone := ctx.Done()
-		go func() {
-			defer func() {
-				close(dfsEventCh)
-				wg.Done()
-			}()
-
-			dfsMessageRegex := regexp.MustCompile(`\bchanged frequency due to DFS detection\b`)
-			//dfsMessageRegex := regexp.MustCompile(`\bhas been disconnected\b`)
-			log.Printf("watching for DFS events with `%v`", dfsMessageRegex)
-			for {
-				select {
-				case <-ctxDone:
-					break
-				case rawLog := <-logsCh:
-					t := rawLog.Tags
-					sort.Strings(t)
-
-					if rawLog.Message != nil && dfsMessageRegex.MatchString(*rawLog.Message) { // && sort.SearchStrings(t, "device-state") != len(t) {
-						dfsEventCh <- rawLog
-					}
-				}
-			}
-
-		}()
-
-		// read from dfsEventCh, log events as we see them
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-ctxDone:
-					break
-				case dfsEvent := <-dfsEventCh:
-					log.Printf("DFS event detected at nn:%d on %s: %s", dfsEvent.NN, dfsEvent.Timestamp, *dfsEvent.Message)
-				}
-			}
-		}()
-	}
-
-	logWatchers := map[string]func(*sync.WaitGroup, <-chan LogEvent){}
-	if a.config.DaemonConfig.DFSEventDetection {
-		id := "dfs"
-		logConsumerChannels[id] = make(chan LogEvent)
-		logWatchers[id] = createDFSEventDetector
-	}
-
-	startLogProducer(ctx, &wg, logFountain)
-	startLogConsumerMultiplexer(ctx, &wg, logFountain)
-	for id, startCoroutine := range logWatchers {
-		// create the log watchers, giving them their own channel to listen on for logs
-		startCoroutine(&wg, logConsumerChannels[id])
-	}
-
-	wg.Wait()
-	return nil
-}
-
-func (a *App) RunDaemon(daemonCtx context.Context) (errs []error) {
-	coroutines := []func(context.Context) error{
-		a.coroutineLogWatch,
-	}
-
-	errCh := make(chan error)
-	wgDone := make(chan bool)
-
-	// TODO: coroutines should map into a channel of errors
-	wg := sync.WaitGroup{}
-	for i, cr := range coroutines {
-		i := i // local variable, so we dont lose track of which coroutine is which
-		wg.Add(1)
-		go func(routine func(context.Context) error) {
-			err := routine(daemonCtx)
-			if err != nil {
-				log.Printf("daemon coroutine %d failed: %s", i, err.Error())
-				errCh <- err
-			}
-			wg.Done()
-		}(cr)
-	}
-
-	go func() {
-		wg.Wait()
-		close(wgDone) // make sure to close the done channel, so we know when to wrap up
-	}()
-
-	select {
-	case <-wgDone:
-		break
-	case err := <-errCh:
-		errs = append(errs, err)
-	}
-
-	return errs
-}

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -121,14 +121,15 @@ func (a *App) logConsumerDFSEventDetector(ctx context.Context, wg *sync.WaitGrou
 					log.Printf("slack support disabled via --enable-slack=false")
 					continue
 				}
-				slackChannelID, err := lookupSlackChannelIDFromNN(dfsEvent.NN)
 
+				slackChannel, err := lookupSlackChannelIDFromNN(dfsEvent.NN)
 				if err != nil {
 					log.Printf("Unable to resolve slack channel: %s", err.Error())
-					log.Printf("Skipping sending slack notification for nn:%d", dfsEvent.NN)
-					continue
+					log.Printf("Using default monitoring channel %s", DefaultMonitoringChannel)
+					slackChannel = DefaultMonitoringChannel
 				}
-				log.Printf("notifying slack channel %s of DFS on nn:%d %s", slackChannelID, dfsEvent.NN, dfsEvent.Device.Name)
+
+				log.Printf("notifying slack channel %s of DFS on nn:%d %s", slackChannel, dfsEvent.NN, dfsEvent.Device.Name)
 				go func() {
 					// TODO: add buttons to link out to UISP for the device triggering the event
 					attachment := slack.Attachment{
@@ -137,7 +138,7 @@ func (a *App) logConsumerDFSEventDetector(ctx context.Context, wg *sync.WaitGrou
 					}
 
 					channelID, timestamp, err := a.Slack.PostMessage(
-						slackChannelID,
+						slackChannel,
 						slack.MsgOptionText("nothing here", false),
 						slack.MsgOptionAttachments(attachment),
 						slack.MsgOptionAsUser(true), // Add this if you want that the bot would post message as a user, otherwise it will send response using the default slackbot

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -143,9 +143,10 @@ func (a *App) coroutineLogWatch(ctx context.Context) error {
 }
 
 func (a *App) RunDaemon(daemonCtx context.Context) (errs []error) {
-	coroutines := []func(context.Context) error{
-		// NOTE(gabe): define all tasks that should run within the context of the daemon here
-		a.coroutineLogWatch,
+	coroutines := []func(context.Context) error{}
+
+	if a.config.DFSEventDetection {
+		coroutines = append(coroutines, a.coroutineLogWatch)
 	}
 
 	errCh := make(chan error)

--- a/pkg/app/daemon.go
+++ b/pkg/app/daemon.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/slack-go/slack"
 )
 
 var (
@@ -106,7 +108,6 @@ func (a *App) logConsumerDFSEventDetector(ctx context.Context, wg *sync.WaitGrou
 	}()
 
 	// read from dfsEventCh, log events as we see them
-	// TODO: this is where we will bolt in the slack support for notifying channels when events are detected
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -116,6 +117,36 @@ func (a *App) logConsumerDFSEventDetector(ctx context.Context, wg *sync.WaitGrou
 				break
 			case dfsEvent := <-dfsEventCh:
 				log.Printf("DFS event detected at nn:%d on %s: %s", dfsEvent.NN, dfsEvent.Timestamp, *dfsEvent.Message)
+				if a.config.EnableSlack {
+					slackChannelID, err := lookupSlackChannelIDFromNN(dfsEvent.NN)
+
+					if err != nil {
+						log.Printf("Unable to resolve slack channel: %s", err.Error())
+						log.Printf("Skipping sending slack notification for nn:%d", dfsEvent.NN)
+						continue
+					}
+					log.Printf("notifying slack channel %s of DFS on nn:%d %s", slackChannelID, dfsEvent.NN, dfsEvent.Device.Name)
+					go func() {
+						// TODO: add buttons to link out to UISP for the device triggering the event
+						attachment := slack.Attachment{
+							Pretext: ":warning:",
+							Text:    *dfsEvent.Message,
+						}
+
+						channelID, timestamp, err := a.Slack.PostMessage(
+							slackChannelID,
+							slack.MsgOptionText("nothing here", false),
+							slack.MsgOptionAttachments(attachment),
+							slack.MsgOptionAsUser(true), // Add this if you want that the bot would post message as a user, otherwise it will send response using the default slackbot
+						)
+						if err != nil {
+							log.Printf("Slack error: %s\n", err.Error())
+							return
+						} else {
+							log.Printf("Message successfully sent to channel %s at %s", channelID, timestamp)
+						}
+					}()
+				}
 			}
 		}
 	}()

--- a/pkg/app/slack.go
+++ b/pkg/app/slack.go
@@ -4,7 +4,8 @@ import "fmt"
 
 var (
 	// TODO: make this mapping dynamic
-	NNToSlackChannel = map[int]string{
+	DefaultMonitoringChannel = "CSJK7P7C3" // #monitoring-unms
+	NNToSlackChannel         = map[int]string{
 		//713:  "CAZ4V9E0P",   // #sn3
 		//713:  "C02HZLLH85R", // #hub-clay-5712
 		5712: "C02HZLLH85R", // #hub-clay-5712

--- a/pkg/app/slack.go
+++ b/pkg/app/slack.go
@@ -6,6 +6,7 @@ var (
 	// TODO: make this mapping dynamic
 	NNToSlackChannel = map[int]string{
 		//713:  "CAZ4V9E0P",   // #sn3
+		//713:  "C02HZLLH85R", // #hub-clay-5712
 		5712: "C02HZLLH85R", // #hub-clay-5712
 	}
 )

--- a/pkg/app/slack.go
+++ b/pkg/app/slack.go
@@ -1,0 +1,18 @@
+package app
+
+import "fmt"
+
+var (
+	// TODO: make this mapping dynamic
+	NNToSlackChannel = map[int]string{
+		//713:  "CAZ4V9E0P",   // #sn3
+		5712: "C02HZLLH85R", // #hub-clay-5712
+	}
+)
+
+func lookupSlackChannelIDFromNN(nn int) (string, error) {
+	if ch, ok := NNToSlackChannel[nn]; ok {
+		return ch, nil
+	}
+	return "", fmt.Errorf("implement me: lookup of slack channel for nn:%d", nn)
+}


### PR DESCRIPTION
More infrastructure to get the Slack API client working, and a nice golden path established to post to slack when DFS events are observed by the daemon.

Caveats:
- we cannot intuitively map from `nn` to the nn's channel (i.e. #hub-xxxx-nn), so for now there is a static mapping of NN to channel ID. If a DFS event is observed on a `nn` without this mapping, no slack message will be sent.
- If the `--enable-slack` flag is omitted, the daemon will not attempt to post to slack at all
- the slack message formatting could use some love. I suspect we will want to workshop it a bunch to make it high SNR, i.e. by adding links out to the UISP device, graphs/logs, etc from slack directly


Example:

```
❱  bin/nycmesh-tool daemon --enable-slack
2022/02/08 14:02:53 config file: /home/gabe/.nycmesh-tool.yaml
2022/02/08 14:02:53 binary release v0.4.0-17-ge47d566, built Tue Feb  8 07:02:25 PM UTC 2022
2022/02/08 14:02:53 launching daemon...                                
2022/02/08 14:02:53 bootstrapping by fetching logs 48h0m0s old
2022/02/08 14:02:53 watching for DFS events with `\bchanged frequency due to DFS detection\b`
2022/02/08 14:03:12 DFS event detected at nn:713 on 2022-02-07T14:18:20.836Z: Device nycmesh-sn3-south main radio changed frequency due to DFS detection
2022/02/08 14:03:12 notifying slack channel C02HZLLH85R of DFS on nn:713 nycmesh-sn3-south
```